### PR TITLE
Allow overriding of partner_id

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fountain-papi (1.0.1)
+    fountain-papi (1.1.0)
       dry-struct (~> 1.4)
       httparty (~> 0.20.0)
 

--- a/lib/fountain/papi/applicant/create_status.rb
+++ b/lib/fountain/papi/applicant/create_status.rb
@@ -15,8 +15,9 @@ module Fountain
         end
 
         def call
+          uri = Fountain::Papi.config.base_uri(override_partner_id: status.partner_id)
           response = Client.post(
-            "#{Fountain::Papi.config.base_uri}/applicants/#{status.applicant_id}/status",
+            "#{uri}/applicants/#{status.applicant_id}/status",
             body: { applicant: { partner_status: status } }.to_json,
             headers: Fountain::Papi.config.headers
           )

--- a/lib/fountain/papi/applicant/status.rb
+++ b/lib/fountain/papi/applicant/status.rb
@@ -25,6 +25,9 @@ module Fountain
         attribute? :external_id, Types::UUID.optional
         attribute? :show_redo, Types::Params::Bool.optional
         attribute? :status_type, Types::Strict::String.optional
+
+        # config override attributes:
+        attribute? :partner_id, Types::UUID.optional
       end
     end
   end

--- a/lib/fountain/papi/config.rb
+++ b/lib/fountain/papi/config.rb
@@ -13,8 +13,8 @@ module Fountain
         @base_domain = "https://partners-sandbox.fountain.com" # Default to sandbox base domain
       end
 
-      def base_uri
-        "#{base_domain}/v#{version}/partners/#{partner_id}"
+      def base_uri(override_partner_id: nil)
+        "#{base_domain}/v#{version}/partners/#{override_partner_id || partner_id}"
       end
 
       def headers

--- a/lib/fountain/papi/version.rb
+++ b/lib/fountain/papi/version.rb
@@ -2,6 +2,6 @@
 
 module Fountain
   module Papi
-    VERSION = "1.0.1"
+    VERSION = "1.1.0"
   end
 end

--- a/spec/fountain/papi/applicant/create_status_spec.rb
+++ b/spec/fountain/papi/applicant/create_status_spec.rb
@@ -47,6 +47,30 @@ describe Fountain::Papi::Applicant::CreateStatus do
       expect(result.url).to eq("https://www.fountain.com")
     end
 
+    context "when a partner_id is provided" do
+      let(:new_partner_id) { SecureRandom.uuid }
+      let(:params) do
+        {
+          applicant_id: "45243c79-981a-4b5c-9c24-117381aabc1b",
+          status: "completed",
+          title: "Our new title",
+          partner_id: new_partner_id
+        }
+      end
+
+      it "overrides the parter_id in the base_uri" do
+        subject
+
+        base_domain = Fountain::Papi.config.base_domain
+        version = Fountain::Papi.config.version
+        base_uri = "#{base_domain}/v#{version}/partners/#{new_partner_id}"
+
+        expect(
+          a_request(:post, "#{base_uri}/applicants/45243c79-981a-4b5c-9c24-117381aabc1b/status")
+        ).to have_been_made
+      end
+    end
+
     context "when missing applicant_id" do
       before { params.delete(:applicant_id) }
 

--- a/spec/fountain/papi/config_spec.rb
+++ b/spec/fountain/papi/config_spec.rb
@@ -34,18 +34,34 @@ describe Fountain::Papi::Config do
     expect(Fountain::Papi.config.sandbox).to eq(false)
   end
 
-  it "returns the correct sandbox base_uri" do
-    Fountain::Papi.configure do |c|
-      c.partner_id = partner_id
-    end
-
-    expect(Fountain::Papi.config.base_uri).to eq("https://partners-sandbox.fountain.com/v1/partners/#{partner_id}")
-  end
-
   it "returns the proper API headers" do
     Fountain::Papi.configure { |c| c.api_key = api_key }
 
     expect(Fountain::Papi.config.headers).to include("Content-Type" => "application/json", "X-ACCESS-TOKEN" => api_key)
+  end
+
+  describe "#base_uri" do
+    context "when no partner_id is specified" do
+      it "returns the correct sandbox base_uri" do
+        Fountain::Papi.configure do |c|
+          c.partner_id = partner_id
+        end
+
+        expect(Fountain::Papi.config.base_uri).to eq("https://partners-sandbox.fountain.com/v1/partners/#{partner_id}")
+      end
+    end
+
+    context "when a partner_id is specified" do
+      let(:new_partner_id) { SecureRandom.uuid }
+
+      it "returns the correct sandbox base_uri" do
+        Fountain::Papi.configure do |c|
+          c.partner_id = partner_id
+        end
+
+        expect(Fountain::Papi.config.base_uri(override_partner_id: new_partner_id)).to eq("https://partners-sandbox.fountain.com/v1/partners/#{new_partner_id}")
+      end
+    end
   end
 
   context "when no version specified" do


### PR DESCRIPTION
This should be a backwards-compatible change:
- `#base_uri` has a default value for `partner_id`
- The `partner_id` attribute is optional on `Status`

I also bumped the version, although I'm not sure if there's an automated job which handles that.