### PR TITLE
Upgrade minimum version of Ruby to 3.0

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Ruby 2.6
+    - name: Set up Ruby 3.0
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 3.0.x
 
     - name: Publish to GPR
       run: |

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby 3.0
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0.x
+        ruby-version: '3.0'
 
     - name: Publish to GPR
       run: |

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.0
 
 Style/StringLiterals:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,9 @@ Style/StringLiteralsInInterpolation:
 
 Layout/LineLength:
   Max: 120
+
+Metrics/BlockLength:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
-## [0.1.0] - 2022-06-01
+## [1.0.0] - 2023-04-13
+- Bump minimum version of Ruby to 3.0
 
+## [0.1.0] - 2022-06-01
 - Initial release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fountain-papi (1.0.0)
+    fountain-papi (1.0.1)
       dry-struct (~> 1.4)
       httparty (~> 0.20.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fountain-papi (0.1.0)
+    fountain-papi (1.0.0)
       dry-struct (~> 1.4)
       httparty (~> 0.20.0)
 
@@ -12,32 +12,29 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     coderay (1.1.3)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
-    dry-configurable (0.15.0)
+    dry-core (1.0.0)
       concurrent-ruby (~> 1.0)
-      dry-core (~> 0.6)
-    dry-container (0.9.0)
+      zeitwerk (~> 2.6)
+    dry-inflector (1.0.0)
+    dry-logic (1.5.0)
       concurrent-ruby (~> 1.0)
-      dry-configurable (~> 0.13, >= 0.13.0)
-    dry-core (0.7.1)
-      concurrent-ruby (~> 1.0)
-    dry-inflector (0.2.1)
-    dry-logic (1.2.0)
-      concurrent-ruby (~> 1.0)
-      dry-core (~> 0.5, >= 0.5)
-    dry-struct (1.4.0)
-      dry-core (~> 0.5, >= 0.5)
-      dry-types (~> 1.5)
+      dry-core (~> 1.0, < 2)
+      zeitwerk (~> 2.6)
+    dry-struct (1.6.0)
+      dry-core (~> 1.0, < 2)
+      dry-types (>= 1.7, < 2)
       ice_nine (~> 0.11)
-    dry-types (1.5.1)
+      zeitwerk (~> 2.6)
+    dry-types (1.7.1)
       concurrent-ruby (~> 1.0)
-      dry-container (~> 0.3)
-      dry-core (~> 0.5, >= 0.5)
-      dry-inflector (~> 0.1, >= 0.1.2)
-      dry-logic (~> 1.0, >= 1.0.2)
+      dry-core (~> 1.0)
+      dry-inflector (~> 1.0)
+      dry-logic (~> 1.4)
+      zeitwerk (~> 2.6)
     hashdiff (1.0.1)
     httparty (0.20.0)
       mime-types (~> 3.0)
@@ -46,7 +43,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
+    mime-types-data (3.2023.0218.1)
     multi_xml (0.6.0)
     parallel (1.22.1)
     parser (3.1.2.0)
@@ -89,9 +86,13 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    zeitwerk (2.6.7)
 
 PLATFORMS
+  arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   fountain-papi!
@@ -102,4 +103,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.6
+   2.3.22

--- a/fountain-papi.gemspec
+++ b/fountain-papi.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "Fountain's Partner API for integrations. See more details: https://partners.fountain.com"
   spec.homepage = "https://github.com/onboardiq/fountain-papi"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/onboardiq/fountain-papi"

--- a/fountain-papi.gemspec
+++ b/fountain-papi.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-struct", "~> 1.4"
   spec.add_dependency "httparty", "~> 0.20.0"
 
-  spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock"
 end

--- a/lib/fountain/papi/applicant/create_status.rb
+++ b/lib/fountain/papi/applicant/create_status.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fountain
   module Papi
     def self.create_status(params)

--- a/lib/fountain/papi/applicant/create_status.rb
+++ b/lib/fountain/papi/applicant/create_status.rb
@@ -21,14 +21,14 @@ module Fountain
             headers: Fountain::Papi.config.headers
           )
 
-          raise Fountain::Papi::Error.new(response) unless response.success?
+          raise Fountain::Papi::Error, response unless response.success?
 
           created_status(response)
         end
 
         def created_status(response)
-          result_status = response["partner_status"].
-            merge(applicant_id: status.applicant_id)
+          result_status = response["partner_status"]
+                          .merge(applicant_id: status.applicant_id)
 
           Fountain::Papi::Applicant::Status.new(result_status)
         end

--- a/lib/fountain/papi/applicant/status.rb
+++ b/lib/fountain/papi/applicant/status.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fountain
   module Papi
     module Applicant

--- a/lib/fountain/papi/client.rb
+++ b/lib/fountain/papi/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fountain
   module Papi
     class Client

--- a/lib/fountain/papi/config.rb
+++ b/lib/fountain/papi/config.rb
@@ -1,11 +1,9 @@
+# frozen_string_literal: true
+
 module Fountain
   module Papi
     class Config
-      attr_accessor :api_key
-      attr_accessor :partner_id
-      attr_accessor :sandbox
-      attr_accessor :version
-      attr_accessor :base_domain
+      attr_accessor :api_key, :partner_id, :sandbox, :version, :base_domain
 
       def initialize
         @api_key = nil    # Partner API Key

--- a/lib/fountain/papi/types.rb
+++ b/lib/fountain/papi/types.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module Fountain
   module Papi
     module Types
       include Dry.Types()
 
-      UUID = Strict::String.
-        constrained(format: /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i)
+      UUID = Strict::String
+             .constrained(format: /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i)
     end
   end
 end

--- a/lib/fountain/papi/version.rb
+++ b/lib/fountain/papi/version.rb
@@ -2,6 +2,6 @@
 
 module Fountain
   module Papi
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end

--- a/lib/fountain/papi/version.rb
+++ b/lib/fountain/papi/version.rb
@@ -2,6 +2,6 @@
 
 module Fountain
   module Papi
-    VERSION = "0.1.0"
+    VERSION = "1.0.0"
   end
 end

--- a/spec/fountain/papi/applicant/create_status_spec.rb
+++ b/spec/fountain/papi/applicant/create_status_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Fountain::Papi::Applicant::CreateStatus do
@@ -13,8 +15,8 @@ describe Fountain::Papi::Applicant::CreateStatus do
     subject(:result) { Fountain::Papi.create_status(**params) }
 
     before do
-      stub_request(:post, /applicants\/#{params[:applicant_id]}\/status/).
-        to_return(
+      stub_request(:post, %r{applicants/#{params[:applicant_id]}/status})
+        .to_return(
           body: File.read("./spec/fixtures/partner_status.json"),
           status: 201
         )
@@ -71,8 +73,8 @@ describe Fountain::Papi::Applicant::CreateStatus do
 
     context "when an API error occurs" do
       before do
-        stub_request(:post, /applicants\/#{params[:applicant_id]}\/status/).
-          to_return(
+        stub_request(:post, %r{applicants/#{params[:applicant_id]}/status})
+          .to_return(
             body: File.read("./spec/fixtures/error.json"),
             status: 400
           )

--- a/spec/fountain/papi/config_spec.rb
+++ b/spec/fountain/papi/config_spec.rb
@@ -60,4 +60,3 @@ describe Fountain::Papi::Config do
     end
   end
 end
-

--- a/spec/fountain/papi/config_spec.rb
+++ b/spec/fountain/papi/config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Fountain::Papi::Config do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 require "fountain/papi"
 


### PR DESCRIPTION
Ruby 2.7 is past EOL, so we shouldn't support it going forward.

This is a non-backwards compatible change, so I also bumped the major version of this gem.